### PR TITLE
Update Ticker.cpp

### DIFF
--- a/libraries/Ticker/src/Ticker.cpp
+++ b/libraries/Ticker/src/Ticker.cpp
@@ -56,3 +56,7 @@ void Ticker::detach() {
     _timer = nullptr;
   }
 }
+
+void Ticker::active() {
+  return (bool)_timer; 
+}


### PR DESCRIPTION
fix error when called active(): `undefined reference to Ticker::active()`

Methods enable, but not defined.
